### PR TITLE
Enable "Edit on GitHub" link by defining `:github_url:` in `index.rst`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,11 @@
+:github_url: https://github.com/microbiomedata/enviroMS/blob/master/docs/index.rst
+
+..
+   Note: The above `github_url` field is used to force the target of the "Edit on GitHub" link
+         to be the specified URL. That makes it so the link will work, regardless of the Sphinx
+         site the file is incorporated into. You can learn more about the `github_url` field at:
+         https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-github_url
+
 Natural Organic Matter Workflow
 ================================
 


### PR DESCRIPTION
On this PR branch, I made it so that — when the documentation source file from this repo is pulled into the centralized documentation website (implemented in the `docs` repo) and built into a web page — the "Edit on GitHub" link on that web page points to the correct source file on GitHub.